### PR TITLE
GH-Action core test with plots based on atime computations with respect to data.table

### DIFF
--- a/plotGenerator.r
+++ b/plotGenerator.r
@@ -1,6 +1,0 @@
-library(ggplot2)
-library(directlabels)
-
-# Plot generating code
-
-ggsave(filename = 'plot.png', plot = last_plot())


### PR DESCRIPTION
Time to test my workflow:)

Any change would have worked here as my GitHub Action is PR-based for the trigger, but since I want to merge this one, I removed the plot-generating script as it's no longer required - I only created it to test the plot commenting feature wherein one can specify the R code used to generate their plots. As it currently stands, the plots are produced by running `atime::atime_pkg( ... )`, meaning that the generator code will always be the same. Thus, there isn't much point in retaining flexibility there.